### PR TITLE
upgrade to TS SDK 0.16.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "dotenv": "^10.0.0",
         "express": "4.x",
         "mailgun-js": "^0.22.0",
-        "temporalio": "0.16.x"
+        "temporalio": "0.16.x",
+        "uuid": "8.x"
       },
       "devDependencies": {
         "@awaitjs/express": "0.8.0",
@@ -20,6 +21,7 @@
         "@types/mailgun-js": "0.22.12",
         "@types/mocha": "9.0.0",
         "@types/sinon": "10.0.4",
+        "@types/uuid": "8.x",
         "axios": "0.23.0",
         "mocha": "9.1.2",
         "nodemon": "^2.0.12",
@@ -415,6 +417,12 @@
       "dependencies": {
         "@sinonjs/fake-timers": "^7.1.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
+      "dev": true
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -4595,6 +4603,12 @@
       "requires": {
         "@sinonjs/fake-timers": "^7.1.0"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.3.tgz",
+      "integrity": "sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==",
+      "dev": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "dotenv": "^10.0.0",
         "express": "4.x",
         "mailgun-js": "^0.22.0",
-        "temporalio": "0.11.x"
+        "temporalio": "0.16.x"
       },
       "devDependencies": {
         "@awaitjs/express": "0.8.0",
@@ -40,9 +40,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.1.tgz",
-      "integrity": "sha512-/chkA48TdAvATHA7RXJPeHQLdfFhpu51974s8htjO/XTDHA41j5+SkR5Io+lr9XsLmkZD6HxLyRAFGmA9wjO2w==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.4.tgz",
+      "integrity": "sha512-a6222b7Dl6fIlMgzVl7e+NiRoLiZFbpcwvBH2Oli56Bn7W4/3Ld+86hK4ffPn5rx2DlDidmIcvIJiOQXyhv9gA==",
       "dependencies": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
@@ -52,9 +52,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.5.tgz",
-      "integrity": "sha512-GZdzyVQI1Bln/kCzIYgTKu+rQJ5dno0gVrfmLe4jqQu7T2e7svSwJzpCBqVU5hhBSJP3peuPjOMWsj5GR61YmQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.7.tgz",
+      "integrity": "sha512-QzTPIyJxU0u+r2qGe8VMl3j/W2ryhEvBv7hc42OjYfthSj370fUrb7na65rG6w3YLZS/fb8p89iTBobfWGDgdw==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -188,74 +188,75 @@
       }
     },
     "node_modules/@temporalio/activity": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.11.0.tgz",
-      "integrity": "sha512-E/8hRYMKhffOSfxhrn7GjGXjFKQqmIx+da5ewOrABcW0ZfG91aiWPslw5wAtlF5+ImsLpCcm9Ro+G7QxvHGv5w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.16.0.tgz",
+      "integrity": "sha512-dov8fbgZUGXyZD8TyNsAnB1VicUbUplG8qEQNGjaSDavHkCymspIJE/4dsceODhBoV6vFoE3aH2pkNdMsAJwSg==",
       "dependencies": {
+        "@temporalio/common": "^0.16.0",
         "abort-controller": "^3.0.0"
       }
     },
     "node_modules/@temporalio/client": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.11.0.tgz",
-      "integrity": "sha512-96HXl+HKbx66cR1N58Irz0sUBLFTZXGFasZFeGn2ZU0X9AuvdjsRK9c+dhh8yMhW98xUx6i720pzuyX68gPxQg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.16.0.tgz",
+      "integrity": "sha512-I8bXJtwsxGrVwUsbvF27d8IjTXjOllc9bCk0zPkAjxb3cEs4bqQi9+e+wyu0ssjOXB7sNRkUwi0xa/nzKw66kg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.7",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
         "ms": "^2.1.3",
         "protobufjs": "^6.11.2",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/@temporalio/common": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.11.0.tgz",
-      "integrity": "sha512-zuWjxiFNDWqp4uFZNcUOggE4mpvGzXIOD0zpQItQMRwmm56fHPyuyEyXaCXFFKDtXDfYMH5kchLmS8W+V0UN+A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-bzmPmYmuaxrwH7VlUrhbsqYCY+zRid6W5aoNWjKjtU0/GF7a7YdRwTZD5A0QOCd2Cp7ozMlBWGtWcYA4/Z9ABQ==",
       "dependencies": {
-        "@temporalio/proto": "^0.11.0",
+        "@temporalio/proto": "^0.16.0",
         "ms": "^2.1.3"
       }
     },
     "node_modules/@temporalio/core-bridge": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.11.0.tgz",
-      "integrity": "sha512-uaMdyXX8Plrw21vWugrQ50+2Xtyj4k8TmokCITMLRPdrtXH/VrWyGGKsABZ6koslXT3+xnuUb5XbWmyPh/+v+Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.16.0.tgz",
+      "integrity": "sha512-7qJAuogs0qsmrcnqNoHWW9F3qYmDXgaVwRYBorALsc+gbDwjLq8UYwiB8OsMJy+Ci4DaIk57IN+lgoFQz7Ax4g==",
       "hasInstallScript": true,
       "dependencies": {
-        "@temporalio/common": "^0.11.0",
-        "cargo-cp-artifact": "^0.1.4"
+        "@opentelemetry/api": "^1.0.3",
+        "@temporalio/common": "^0.16.0",
+        "arg": "^5.0.1",
+        "cargo-cp-artifact": "^0.1.4",
+        "which": "^2.0.2"
       }
     },
     "node_modules/@temporalio/proto": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.11.0.tgz",
-      "integrity": "sha512-13rA6ACbvFqo+FhC6FxlFL5SEi3B+AQTyjfi+tSl5yv/XbZJMpAscIbx6Mga2EG/6bgv8ylcd9HxSEtMleGcuQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.16.0.tgz",
+      "integrity": "sha512-QOkGPzAFXo2KbBMuUT0qNkXziBPfgoZqCzpwdBPfUDw0sHal4ExAc6VvguV+HU/Qk29hkjrvL4k2WKwAb7XKzA==",
       "dependencies": {
-        "@temporalio/core-bridge": "^0.11.0",
         "@types/long": "^4.0.1",
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       }
     },
     "node_modules/@temporalio/worker": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.11.0.tgz",
-      "integrity": "sha512-JZr5LjIwI4utzWV4Jb+EBox4lHdXMcCKieZgVng6E6sExvuNGP9OTSsqGN73nIU5LCi1tNY3OwANbhvHTMRHKw==",
-      "hasInstallScript": true,
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.16.2.tgz",
+      "integrity": "sha512-nHbmI+lo17zsgtOJMMAZQAaGtY+nxaa9eSU1AbHR5d/5UMFOdr3bdCYotlvXkpAEpU3eZE670C//gCPHgBcwIA==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.3",
-        "@temporalio/activity": "^0.11.0",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/core-bridge": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
-        "@temporalio/workflow": "^0.11.0",
+        "@temporalio/activity": "^0.16.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/core-bridge": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
+        "@temporalio/workflow": "^0.16.0",
         "abort-controller": "^3.0.0",
         "cargo-cp-artifact": "^0.1.4",
         "dedent": "^0.7.0",
         "fs-extra": "^10.0.0",
         "heap-js": "^2.1.6",
-        "isolated-vm": "^4.3.4",
         "memfs": "^3.2.2",
         "ms": "^2.1.3",
         "nan": "^2.15.0",
@@ -268,12 +269,12 @@
       }
     },
     "node_modules/@temporalio/workflow": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.11.0.tgz",
-      "integrity": "sha512-Sb7F7LgrHetvuS8VPiRqiVRSPJ+QzKOgU5ntrc4Evo6Urxgx2iMDsnqvQUI/tp3fwY1NwAlFzX556bQXjqXceg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.16.0.tgz",
+      "integrity": "sha512-GpGE3Fwp0I8TMpmmvGc18dRZA2FW8PzxCrI/ktQZxlox5zXSG7if3dzvviy9CH+8Qn0tpntQghmbegFCVP7HoQ==",
       "dependencies": {
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0"
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0"
       }
     },
     "node_modules/@tsconfig/node16": {
@@ -302,9 +303,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-      "integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-74hbvsnc+7TEDa1z5YLSe4/q8hGYB3USNvCuzHUJrjPV6hXaq8IXcngCrHkuvFt0+8rFz7xYXrHgNayIX0UZvQ==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -592,9 +593,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -696,6 +697,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -873,14 +879,14 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.4.tgz",
-      "integrity": "sha512-Zg7RpbZpIJRW3am9Lyckue7PLytvVxxhJj1CaJVlCWENsGEAOlnlt8X0ZxGRPp7Bt9o8tIRM5SEXy4BCPMJjLQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001265",
-        "electron-to-chromium": "^1.3.867",
+        "caniuse-lite": "^1.0.30001280",
+        "electron-to-chromium": "^1.3.896",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.0",
+        "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
       },
       "bin": {
@@ -962,18 +968,18 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw==",
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
       }
     },
     "node_modules/cargo-cp-artifact": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.5.tgz",
-      "integrity": "sha512-mWwNdfrEyvMPxDHoAhbCYwQBNP3RyW9bV+yi5VaaHtVZqoDXbGU5JQF5qG7s65SJhqP7HIVAQD7wZM6Fk2COuw==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
+      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg==",
       "bin": {
         "cargo-cp-artifact": "bin/cargo-cp-artifact.js"
       }
@@ -1332,9 +1338,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.867",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.867.tgz",
-      "integrity": "sha512-WbTXOv7hsLhjJyl7jBfDkioaY++iVVZomZ4dU6TMe/SzucV6mUAs2VZn/AehBwuZMiNEQDaPuTGn22YK5o+aDw=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.4.tgz",
+      "integrity": "sha512-teHtgwcmVcL46jlFvAaqjyiTLWuMrUQO1JqV303JKB4ysXG6m8fXSFhbjal9st0r9mNskI22AraJZorb1VcLVg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1491,9 +1497,9 @@
       }
     },
     "node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-      "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "engines": {
         "node": ">=4.0"
       }
@@ -2282,22 +2288,12 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/isolated-vm": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.3.5.tgz",
-      "integrity": "sha512-wGiZ1JUmuldZKnitygwReAnJhqWC9RFjbNqV1AkjUVO5TI+ProPGTjwVA4++oY+1wC7LSSorJRS7ki5LMJyYJQ==",
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=10.4.0"
-      }
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "node_modules/jest-worker": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
-      "integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
+      "version": "27.3.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
+      "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -2517,9 +2513,9 @@
       }
     },
     "node_modules/memfs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
-      "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.0.tgz",
+      "integrity": "sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==",
       "dependencies": {
         "fs-monkey": "1.0.3"
       },
@@ -2714,9 +2710,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.0.tgz",
-      "integrity": "sha512-aA87l0flFYMzCHpTM3DERFSYxc6lv/BltdbRTOMZuxZ0cwZCD3mejE5n9vLhSJCN++/eOqr77G1IO5uXxlQYWA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
     "node_modules/nodemon": {
       "version": "2.0.13",
@@ -2859,6 +2855,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3527,9 +3524,9 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -3615,25 +3612,25 @@
       }
     },
     "node_modules/temporalio": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.11.0.tgz",
-      "integrity": "sha512-XJGsVf5yb4ZvkPk/J1lKykP/RAaEjJCs+NxFGUERgiJoymbDweCc9NUAPM0/yiWe1X5diwOuT/+dKOJHbcU7JA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.16.2.tgz",
+      "integrity": "sha512-wniSk0PF+xUAdMKXyuSzOju3BDpcOrUZfuD4LhMOSfdU+oOE+8wgFXqXA/r1c4RRUfk780EATkAD234g8uvzMQ==",
       "dependencies": {
-        "@temporalio/activity": "^0.11.0",
-        "@temporalio/client": "^0.11.0",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
-        "@temporalio/worker": "^0.11.0",
-        "@temporalio/workflow": "^0.11.0"
+        "@temporalio/activity": "^0.16.0",
+        "@temporalio/client": "^0.16.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
+        "@temporalio/worker": "^0.16.2",
+        "@temporalio/workflow": "^0.16.0"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/terser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-      "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
       "dependencies": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -3644,15 +3641,22 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "acorn": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "acorn": {
+          "optional": true
+        }
       }
     },
     "node_modules/terser-webpack-plugin": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
-      "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
+      "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
       "dependencies": {
         "jest-worker": "^27.0.6",
-        "p-limit": "^3.1.0",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
@@ -3996,9 +4000,9 @@
       }
     },
     "node_modules/watchpack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-      "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
+      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -4008,9 +4012,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.2.tgz",
-      "integrity": "sha512-3S6e9Vo1W2ijk4F4PPWRIu6D/uGgqaPmqw+av3W3jLDujuNkdxX5h5c+RQ6GkjVR+WwIPOfgY8av+j5j4tMqJw==",
+      "version": "5.64.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
+      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -4034,8 +4038,8 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
-        "webpack-sources": "^3.2.0"
+        "watchpack": "^2.3.0",
+        "webpack-sources": "^3.2.2"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -4054,9 +4058,9 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
+      "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -4065,7 +4069,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -4218,6 +4221,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -4235,18 +4239,18 @@
       "requires": {}
     },
     "@grpc/grpc-js": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.1.tgz",
-      "integrity": "sha512-/chkA48TdAvATHA7RXJPeHQLdfFhpu51974s8htjO/XTDHA41j5+SkR5Io+lr9XsLmkZD6HxLyRAFGmA9wjO2w==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.4.4.tgz",
+      "integrity": "sha512-a6222b7Dl6fIlMgzVl7e+NiRoLiZFbpcwvBH2Oli56Bn7W4/3Ld+86hK4ffPn5rx2DlDidmIcvIJiOQXyhv9gA==",
       "requires": {
         "@grpc/proto-loader": "^0.6.4",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.5.tgz",
-      "integrity": "sha512-GZdzyVQI1Bln/kCzIYgTKu+rQJ5dno0gVrfmLe4jqQu7T2e7svSwJzpCBqVU5hhBSJP3peuPjOMWsj5GR61YmQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.7.tgz",
+      "integrity": "sha512-QzTPIyJxU0u+r2qGe8VMl3j/W2ryhEvBv7hc42OjYfthSj370fUrb7na65rG6w3YLZS/fb8p89iTBobfWGDgdw==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -4365,72 +4369,74 @@
       }
     },
     "@temporalio/activity": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.11.0.tgz",
-      "integrity": "sha512-E/8hRYMKhffOSfxhrn7GjGXjFKQqmIx+da5ewOrABcW0ZfG91aiWPslw5wAtlF5+ImsLpCcm9Ro+G7QxvHGv5w==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/activity/-/activity-0.16.0.tgz",
+      "integrity": "sha512-dov8fbgZUGXyZD8TyNsAnB1VicUbUplG8qEQNGjaSDavHkCymspIJE/4dsceODhBoV6vFoE3aH2pkNdMsAJwSg==",
       "requires": {
+        "@temporalio/common": "^0.16.0",
         "abort-controller": "^3.0.0"
       }
     },
     "@temporalio/client": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.11.0.tgz",
-      "integrity": "sha512-96HXl+HKbx66cR1N58Irz0sUBLFTZXGFasZFeGn2ZU0X9AuvdjsRK9c+dhh8yMhW98xUx6i720pzuyX68gPxQg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/client/-/client-0.16.0.tgz",
+      "integrity": "sha512-I8bXJtwsxGrVwUsbvF27d8IjTXjOllc9bCk0zPkAjxb3cEs4bqQi9+e+wyu0ssjOXB7sNRkUwi0xa/nzKw66kg==",
       "requires": {
         "@grpc/grpc-js": "^1.3.7",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
         "ms": "^2.1.3",
         "protobufjs": "^6.11.2",
         "uuid": "^8.3.2"
       }
     },
     "@temporalio/common": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.11.0.tgz",
-      "integrity": "sha512-zuWjxiFNDWqp4uFZNcUOggE4mpvGzXIOD0zpQItQMRwmm56fHPyuyEyXaCXFFKDtXDfYMH5kchLmS8W+V0UN+A==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/common/-/common-0.16.0.tgz",
+      "integrity": "sha512-bzmPmYmuaxrwH7VlUrhbsqYCY+zRid6W5aoNWjKjtU0/GF7a7YdRwTZD5A0QOCd2Cp7ozMlBWGtWcYA4/Z9ABQ==",
       "requires": {
-        "@temporalio/proto": "^0.11.0",
+        "@temporalio/proto": "^0.16.0",
         "ms": "^2.1.3"
       }
     },
     "@temporalio/core-bridge": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.11.0.tgz",
-      "integrity": "sha512-uaMdyXX8Plrw21vWugrQ50+2Xtyj4k8TmokCITMLRPdrtXH/VrWyGGKsABZ6koslXT3+xnuUb5XbWmyPh/+v+Q==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/core-bridge/-/core-bridge-0.16.0.tgz",
+      "integrity": "sha512-7qJAuogs0qsmrcnqNoHWW9F3qYmDXgaVwRYBorALsc+gbDwjLq8UYwiB8OsMJy+Ci4DaIk57IN+lgoFQz7Ax4g==",
       "requires": {
-        "@temporalio/common": "^0.11.0",
-        "cargo-cp-artifact": "^0.1.4"
+        "@opentelemetry/api": "^1.0.3",
+        "@temporalio/common": "^0.16.0",
+        "arg": "^5.0.1",
+        "cargo-cp-artifact": "^0.1.4",
+        "which": "^2.0.2"
       }
     },
     "@temporalio/proto": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.11.0.tgz",
-      "integrity": "sha512-13rA6ACbvFqo+FhC6FxlFL5SEi3B+AQTyjfi+tSl5yv/XbZJMpAscIbx6Mga2EG/6bgv8ylcd9HxSEtMleGcuQ==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/proto/-/proto-0.16.0.tgz",
+      "integrity": "sha512-QOkGPzAFXo2KbBMuUT0qNkXziBPfgoZqCzpwdBPfUDw0sHal4ExAc6VvguV+HU/Qk29hkjrvL4k2WKwAb7XKzA==",
       "requires": {
-        "@temporalio/core-bridge": "^0.11.0",
         "@types/long": "^4.0.1",
         "long": "^4.0.0",
         "protobufjs": "^6.11.2"
       }
     },
     "@temporalio/worker": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.11.0.tgz",
-      "integrity": "sha512-JZr5LjIwI4utzWV4Jb+EBox4lHdXMcCKieZgVng6E6sExvuNGP9OTSsqGN73nIU5LCi1tNY3OwANbhvHTMRHKw==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@temporalio/worker/-/worker-0.16.2.tgz",
+      "integrity": "sha512-nHbmI+lo17zsgtOJMMAZQAaGtY+nxaa9eSU1AbHR5d/5UMFOdr3bdCYotlvXkpAEpU3eZE670C//gCPHgBcwIA==",
       "requires": {
         "@opentelemetry/api": "^1.0.3",
-        "@temporalio/activity": "^0.11.0",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/core-bridge": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
-        "@temporalio/workflow": "^0.11.0",
+        "@temporalio/activity": "^0.16.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/core-bridge": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
+        "@temporalio/workflow": "^0.16.0",
         "abort-controller": "^3.0.0",
         "cargo-cp-artifact": "^0.1.4",
         "dedent": "^0.7.0",
         "fs-extra": "^10.0.0",
         "heap-js": "^2.1.6",
-        "isolated-vm": "^4.3.4",
         "memfs": "^3.2.2",
         "ms": "^2.1.3",
         "nan": "^2.15.0",
@@ -4443,12 +4449,12 @@
       }
     },
     "@temporalio/workflow": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.11.0.tgz",
-      "integrity": "sha512-Sb7F7LgrHetvuS8VPiRqiVRSPJ+QzKOgU5ntrc4Evo6Urxgx2iMDsnqvQUI/tp3fwY1NwAlFzX556bQXjqXceg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@temporalio/workflow/-/workflow-0.16.0.tgz",
+      "integrity": "sha512-GpGE3Fwp0I8TMpmmvGc18dRZA2FW8PzxCrI/ktQZxlox5zXSG7if3dzvviy9CH+8Qn0tpntQghmbegFCVP7HoQ==",
       "requires": {
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0"
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0"
       }
     },
     "@tsconfig/node16": {
@@ -4477,9 +4483,9 @@
       }
     },
     "@types/eslint": {
-      "version": "7.28.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.1.tgz",
-      "integrity": "sha512-XhZKznR3i/W5dXqUhgU9fFdJekufbeBd5DALmkuXoeFcjbQcPk+2cL+WLHf6Q81HWAnM2vrslIHpGVyCAviRwg==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-74hbvsnc+7TEDa1z5YLSe4/q8hGYB3USNvCuzHUJrjPV6hXaq8IXcngCrHkuvFt0+8rFz7xYXrHgNayIX0UZvQ==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -4761,9 +4767,9 @@
       }
     },
     "acorn": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q=="
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
+      "integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw=="
     },
     "acorn-import-assertions": {
       "version": "1.8.0",
@@ -4833,6 +4839,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "arg": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+      "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA=="
     },
     "argparse": {
       "version": "2.0.1",
@@ -4988,14 +4999,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.17.4.tgz",
-      "integrity": "sha512-Zg7RpbZpIJRW3am9Lyckue7PLytvVxxhJj1CaJVlCWENsGEAOlnlt8X0ZxGRPp7Bt9o8tIRM5SEXy4BCPMJjLQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.18.1.tgz",
+      "integrity": "sha512-8ScCzdpPwR2wQh8IT82CA2VgDwjHyqMovPBZSNH54+tm4Jk2pCuv90gmAdH6J84OCRWi0b4gMe6O6XPXuJnjgQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001265",
-        "electron-to-chromium": "^1.3.867",
+        "caniuse-lite": "^1.0.30001280",
+        "electron-to-chromium": "^1.3.896",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.0",
+        "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
       }
     },
@@ -5048,14 +5059,14 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001265",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001265.tgz",
-      "integrity": "sha512-YzBnspggWV5hep1m9Z6sZVLOt7vrju8xWooFAgN6BA5qvy98qPAPb7vNUzypFaoh2pb3vlfzbDO8tB57UPGbtw=="
+      "version": "1.0.30001283",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001283.tgz",
+      "integrity": "sha512-9RoKo841j1GQFSJz/nCXOj0sD7tHBtlowjYlrqIUS812x9/emfBLBt6IyMz1zIaYc/eRL8Cs6HPUVi2Hzq4sIg=="
     },
     "cargo-cp-artifact": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.5.tgz",
-      "integrity": "sha512-mWwNdfrEyvMPxDHoAhbCYwQBNP3RyW9bV+yi5VaaHtVZqoDXbGU5JQF5qG7s65SJhqP7HIVAQD7wZM6Fk2COuw=="
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/cargo-cp-artifact/-/cargo-cp-artifact-0.1.6.tgz",
+      "integrity": "sha512-CQw0doK/aaF7j041666XzuilHxqMxaKkn+I5vmBsd8SAwS0cO5CqVEVp0xJwOKstyqWZ6WK4Ww3O6p26x/Goyg=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -5334,9 +5345,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.867",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.867.tgz",
-      "integrity": "sha512-WbTXOv7hsLhjJyl7jBfDkioaY++iVVZomZ4dU6TMe/SzucV6mUAs2VZn/AehBwuZMiNEQDaPuTGn22YK5o+aDw=="
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.4.tgz",
+      "integrity": "sha512-teHtgwcmVcL46jlFvAaqjyiTLWuMrUQO1JqV303JKB4ysXG6m8fXSFhbjal9st0r9mNskI22AraJZorb1VcLVg=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -5448,9 +5459,9 @@
       },
       "dependencies": {
         "estraverse": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
-          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
         }
       }
     },
@@ -6067,18 +6078,12 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isolated-vm": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-4.3.5.tgz",
-      "integrity": "sha512-wGiZ1JUmuldZKnitygwReAnJhqWC9RFjbNqV1AkjUVO5TI+ProPGTjwVA4++oY+1wC7LSSorJRS7ki5LMJyYJQ=="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "jest-worker": {
-      "version": "27.2.5",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.2.5.tgz",
-      "integrity": "sha512-HTjEPZtcNKZ4LnhSp02NEH4vE+5OpJ0EsOWYvGQpHgUMLngydESAAMH5Wd/asPf29+XUDQZszxpLg1BkIIA2aw==",
+      "version": "27.3.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.3.1.tgz",
+      "integrity": "sha512-ks3WCzsiZaOPJl/oMsDjaf0TRiSv7ctNgs0FqRr2nARsovz6AWWy4oLElwcquGSz692DzgZQrCLScPNs5YlC4g==",
       "requires": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -6250,9 +6255,9 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "memfs": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.3.0.tgz",
-      "integrity": "sha512-BEE62uMfKOavX3iG7GYX43QJ+hAeeWnwIAuJ/R6q96jaMtiLzhsxHJC8B1L7fK7Pt/vXDRwb3SG/yBpNGDPqzg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.0.tgz",
+      "integrity": "sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==",
       "requires": {
         "fs-monkey": "1.0.3"
       }
@@ -6397,9 +6402,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.0.tgz",
-      "integrity": "sha512-aA87l0flFYMzCHpTM3DERFSYxc6lv/BltdbRTOMZuxZ0cwZCD3mejE5n9vLhSJCN++/eOqr77G1IO5uXxlQYWA=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+      "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
     },
     "nodemon": {
       "version": "2.0.13",
@@ -6506,6 +6511,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -7047,9 +7053,9 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-support": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
-      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -7113,22 +7119,22 @@
       "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "temporalio": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.11.0.tgz",
-      "integrity": "sha512-XJGsVf5yb4ZvkPk/J1lKykP/RAaEjJCs+NxFGUERgiJoymbDweCc9NUAPM0/yiWe1X5diwOuT/+dKOJHbcU7JA==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/temporalio/-/temporalio-0.16.2.tgz",
+      "integrity": "sha512-wniSk0PF+xUAdMKXyuSzOju3BDpcOrUZfuD4LhMOSfdU+oOE+8wgFXqXA/r1c4RRUfk780EATkAD234g8uvzMQ==",
       "requires": {
-        "@temporalio/activity": "^0.11.0",
-        "@temporalio/client": "^0.11.0",
-        "@temporalio/common": "^0.11.0",
-        "@temporalio/proto": "^0.11.0",
-        "@temporalio/worker": "^0.11.0",
-        "@temporalio/workflow": "^0.11.0"
+        "@temporalio/activity": "^0.16.0",
+        "@temporalio/client": "^0.16.0",
+        "@temporalio/common": "^0.16.0",
+        "@temporalio/proto": "^0.16.0",
+        "@temporalio/worker": "^0.16.2",
+        "@temporalio/workflow": "^0.16.0"
       }
     },
     "terser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.9.0.tgz",
-      "integrity": "sha512-h5hxa23sCdpzcye/7b8YqbE5OwKca/ni0RQz1uRX3tGh8haaGHqcuSqbGRybuAKNdntZ0mDgFNXPJ48xQ2RXKQ==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
@@ -7143,12 +7149,11 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.4.tgz",
-      "integrity": "sha512-E2CkNMN+1cho04YpdANyRrn8CyN4yMy+WdFKZIySFZrGXZxJwJP6PMNGGc/Mcr6qygQHUUqRxnAPmi0M9f00XA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.2.5.tgz",
+      "integrity": "sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==",
       "requires": {
         "jest-worker": "^27.0.6",
-        "p-limit": "^3.1.0",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
         "source-map": "^0.6.1",
@@ -7386,18 +7391,18 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "watchpack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-      "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.0.tgz",
+      "integrity": "sha512-MnN0Q1OsvB/GGHETrFeZPQaOelWh/7O+EiFlj8sM9GPjtQkis7k01aAxrg/18kTfoIVcLL+haEVFlXDaSRwKRw==",
       "requires": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
     },
     "webpack": {
-      "version": "5.58.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.58.2.tgz",
-      "integrity": "sha512-3S6e9Vo1W2ijk4F4PPWRIu6D/uGgqaPmqw+av3W3jLDujuNkdxX5h5c+RQ6GkjVR+WwIPOfgY8av+j5j4tMqJw==",
+      "version": "5.64.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.4.tgz",
+      "integrity": "sha512-LWhqfKjCLoYJLKJY8wk2C3h77i8VyHowG3qYNZiIqD6D0ZS40439S/KVuc/PY48jp2yQmy0mhMknq8cys4jFMw==",
       "requires": {
         "@types/eslint-scope": "^3.7.0",
         "@types/estree": "^0.0.50",
@@ -7421,20 +7426,19 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.2.0",
-        "webpack-sources": "^3.2.0"
+        "watchpack": "^2.3.0",
+        "webpack-sources": "^3.2.2"
       }
     },
     "webpack-sources": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.1.tgz",
-      "integrity": "sha512-t6BMVLQ0AkjBOoRTZgqrWm7xbXMBzD+XDq2EZ96+vMfn3qKgsvdXZhbPZ4ElUOpdv4u+iiGe+w3+J75iy/bYGA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
+      "integrity": "sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw=="
     },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -7547,7 +7551,8 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "dotenv": "^10.0.0",
     "express": "4.x",
     "mailgun-js": "^0.22.0",
-    "temporalio": "0.16.x"
+    "temporalio": "0.16.x",
+    "uuid": "8.x"
   },
   "devDependencies": {
     "@awaitjs/express": "0.8.0",
@@ -22,6 +23,7 @@
     "@types/mailgun-js": "0.22.12",
     "@types/mocha": "9.0.0",
     "@types/sinon": "10.0.4",
+    "@types/uuid": "8.x",
     "axios": "0.23.0",
     "mocha": "9.1.2",
     "nodemon": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dotenv": "^10.0.0",
     "express": "4.x",
     "mailgun-js": "^0.22.0",
-    "temporalio": "0.11.x"
+    "temporalio": "0.16.x"
   },
   "devDependencies": {
     "@awaitjs/express": "0.8.0",

--- a/src/api/addToCart.ts
+++ b/src/api/addToCart.ts
@@ -9,8 +9,8 @@ export default async function addToCart(req: Request, res: Response) {
   const quantity: number = req.body.quantity;
   assert.ok(workflowId);
 
-  const workflow = client.createWorkflowHandle<typeof cartWorkflow>({ workflowId });
+  const handle = client.getHandle<typeof cartWorkflow>(workflowId);
 
-  await workflow.signal(addToCartSignal, { productId, quantity });
+  await handle.signal(addToCartSignal, { productId, quantity });
   res.json({ ok: 1 });
 }

--- a/src/api/createCart.ts
+++ b/src/api/createCart.ts
@@ -3,9 +3,11 @@ import { client, taskQueue } from './client';
 import { cartWorkflow } from '../workflows';
 
 export default async function postCart(req: Request, res: Response) {
-  const workflow = client.createWorkflowHandle(cartWorkflow, { taskQueue });
+  const workflowId = 'create-cart-' + Date.now();
+  await client.start(cartWorkflow, {
+    taskQueue,
+    workflowId
+  });
 
-  await workflow.start();
-
-  res.json({ workflowId: workflow.workflowId });
+  res.json({ workflowId });
 }

--- a/src/api/createCart.ts
+++ b/src/api/createCart.ts
@@ -1,9 +1,10 @@
 import { Request, Response } from 'express';
 import { client, taskQueue } from './client';
 import { cartWorkflow } from '../workflows';
+import { v4 as uuidv4 } from 'uuid';
 
-export default async function postCart(req: Request, res: Response) {
-  const workflowId = 'create-cart-' + Date.now();
+export default async function postCart(_req: Request, res: Response) {
+  const workflowId = uuidv4();
   await client.start(cartWorkflow, {
     taskQueue,
     workflowId

--- a/src/api/getCart.ts
+++ b/src/api/getCart.ts
@@ -7,8 +7,8 @@ export default async function getCart(req: Request, res: Response) {
   const workflowId: string = req.params.workflowId;
   assert.ok(workflowId);
 
-  const workflow = client.createWorkflowHandle<typeof cartWorkflow>({ workflowId });
+  const handle = client.getHandle<typeof cartWorkflow>(workflowId);
 
-  const state = await workflow.query(getCartQuery);
+  const state = await handle.query(getCartQuery);
   res.json({ state });
 }

--- a/src/test/workflows.test.ts
+++ b/src/test/workflows.test.ts
@@ -19,7 +19,7 @@ const taskQueue = 'test' + (new Date()).toLocaleDateString('en-US');
 describe('cart workflow', function() {
   let runPromise: Promise<void>;
   let worker: Worker;
-  let workflow: WorkflowHandle<typeof cartWorkflow>;
+  let handle: WorkflowHandle<typeof cartWorkflow>;
   let sendStub: sinon.SinonStub<any[], Promise<any>>; // `any` because `@types/mailgun` doesn't export `SendResponse`
 
   before(async function() {
@@ -40,12 +40,16 @@ describe('cart workflow', function() {
     runPromise = worker.run();
   });
 
-  beforeEach(function() {
+  beforeEach(async function() {
     sendStub.resetHistory();
 
     const client = new WorkflowClient();
 
-    workflow = client.createWorkflowHandle(cartWorkflow, { taskQueue });
+    handle = await client.start(cartWorkflow, {
+      taskQueue,
+      workflowId: 'cart-test-' + Date.now(),
+      args: [{ abandonedCartTimeoutMS: 50 }]
+    });
   });
 
   after(async function() {
@@ -53,73 +57,65 @@ describe('cart workflow', function() {
     await runPromise;
   });
 
-  it('handles adding and removing from cart', async function() {
-    await workflow.start();
-    
-    let state = await workflow.query(getCartQuery);
+  it('handles adding and removing from cart', async function() {    
+    let state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 0);
 
-    await workflow.signal(addToCartSignal, { productId: '1', quantity: 3 });
-    state = await workflow.query(getCartQuery);
+    await handle.signal(addToCartSignal, { productId: '1', quantity: 3 });
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '1', quantity: 3 });
 
-    await workflow.signal(removeFromCartSignal, { productId: '1', quantity: 1 });
-    state = await workflow.query(getCartQuery);
+    await handle.signal(removeFromCartSignal, { productId: '1', quantity: 1 });
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '1', quantity: 2 });
 
-    await workflow.terminate();
+    await handle.terminate();
   });
 
-  it('completes when it receives a checkout signal', async function() {
-    await workflow.start({ abandonedCartTimeoutMS: 50 });
-    
-    let state = await workflow.query(getCartQuery);
+  it('completes when it receives a checkout signal', async function() {    
+    let state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 0);
 
-    await workflow.signal(addToCartSignal, { productId: '2', quantity: 2 });
-    state = await workflow.query(getCartQuery);
+    await handle.signal(addToCartSignal, { productId: '2', quantity: 2 });
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '2', quantity: 2 });
 
-    await workflow.signal(updateEmailSignal, 'test@temporal.io');
-    state = await workflow.query(getCartQuery);
+    await handle.signal(updateEmailSignal, 'test@temporal.io');
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '2', quantity: 2 });
     assert.equal(state.email, 'test@temporal.io');
 
-    await workflow.signal(checkoutSignal);
-    await workflow.result();
+    await handle.signal(checkoutSignal);
+    await handle.result();
 
-    state = await workflow.query(getCartQuery);
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '2', quantity: 2 });
   });
 
   it('sets error status if checking out with no email set', async function() {
-    await workflow.start();
-
-    await workflow.signal(checkoutSignal);
+    await handle.signal(checkoutSignal);
     
-    let state = await workflow.query(getCartQuery);
+    let state = await handle.query(getCartQuery);
     assert.equal(state.status, CartStatus.ERROR);
     assert.equal(state.error, 'Must have email to check out!');
   });
 
   it('sends abandoned cart email', async function() {
-    await workflow.start({ abandonedCartTimeoutMS: 50 });
-    
-    let state = await workflow.query(getCartQuery);
+    let state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 0);
 
-    await workflow.signal(addToCartSignal, { productId: '2', quantity: 2 });
-    state = await workflow.query(getCartQuery);
+    await handle.signal(addToCartSignal, { productId: '2', quantity: 2 });
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '2', quantity: 2 });
 
-    await workflow.signal(updateEmailSignal, 'test@temporal.io');
-    state = await workflow.query(getCartQuery);
+    await handle.signal(updateEmailSignal, 'test@temporal.io');
+    state = await handle.query(getCartQuery);
     assert.equal(state.items.length, 1);
     assert.deepEqual(state.items[0], { productId: '2', quantity: 2 });
     assert.equal(state.email, 'test@temporal.io');

--- a/src/test/workflows.test.ts
+++ b/src/test/workflows.test.ts
@@ -1,4 +1,5 @@
 import { WorkflowClient, WorkflowHandle } from '@temporalio/client';
+import { CartStatus } from '../interfaces';
 import { Core, Worker, DefaultLogger } from '@temporalio/worker';
 import { describe, before, after, it } from 'mocha';
 import {
@@ -12,7 +13,7 @@ import {
 import assert from 'assert';
 import { createActivities } from '../activities';
 import sinon from 'sinon';
-import { CartStatus } from '../interfaces';
+import { v4 as uuidv4 } from 'uuid'
 
 const taskQueue = 'test' + (new Date()).toLocaleDateString('en-US');
 
@@ -47,7 +48,7 @@ describe('cart workflow', function() {
 
     handle = await client.start(cartWorkflow, {
       taskQueue,
-      workflowId: 'cart-test-' + Date.now(),
+      workflowId: 'cart-test-' + uuidv4(),
       args: [{ abandonedCartTimeoutMS: 50 }]
     });
   });


### PR DESCRIPTION
Took a bit to figure out how to upgrade, but samples-typescript makes it pretty easy.

* createActivityHandle -> proxyActivities from here: https://github.com/temporalio/samples-typescript/blob/main/hello-world/src/workflows.ts
* createWorkflowHandle -> start, must provide `workflowId` from here: https://github.com/temporalio/samples-typescript/blob/main/hello-world/src/execute-workflow.ts
* setListener -> setHandler from here: https://github.com/temporalio/samples-typescript/blob/main/signals-queries/src/workflows.ts